### PR TITLE
Check point cloud number and raise ValueError if found empty.

### DIFF
--- a/scene/gaussian_model.py
+++ b/scene/gaussian_model.py
@@ -130,6 +130,8 @@ class GaussianModel:
         features[:, 3:, 1:] = 0.0
 
         print("Number of points at initialisation : ", fused_point_cloud.shape[0])
+        if fused_point_cloud.shape[0] == 0:
+            raise ValueError("Point cloud is empty. Please check the dataset.")
 
         dist2 = torch.clamp_min(distCUDA2(torch.from_numpy(np.asarray(pcd.points)).float().cuda()), 0.0000001)
         scales = torch.log(torch.sqrt(dist2))[...,None].repeat(1, 3)


### PR DESCRIPTION
This addresses solution for mislead error : https://github.com/j-alex-hanson/speedy-splat/issues/5